### PR TITLE
Minor refactor of starting headless session

### DIFF
--- a/lib/onlyoffice_webdriver_wrapper/helpers/headless_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/headless_helper.rb
@@ -17,13 +17,20 @@ module OnlyofficeWebdriverWrapper
       @resolution_y = resolution_y
     end
 
+    # Check if should start headless
+    # @return [True, False] result
+    def should_start?
+      return false if debug?
+      return false if RUBY_PLATFORM.include?('darwin')
+      true
+    end
+
     def start
-      create_session = false
-      if real_display_connected?
-        create_session = true if real_display_resolution_low? || !debug?
-      else
-        create_session = true
-      end
+      create_session = if real_display_connected?
+                         should_start?
+                       else
+                         true
+                       end
       return unless create_session
       OnlyofficeLoggerHelper.log('Starting Headless Session')
       begin

--- a/lib/onlyoffice_webdriver_wrapper/helpers/headless_helper/real_display_tools.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/headless_helper/real_display_tools.rb
@@ -16,13 +16,5 @@ module OnlyofficeWebdriverWrapper
       OnlyofficeLoggerHelper.log("Real Display Exists: #{exists}")
       exists
     end
-
-    def real_display_resolution_low?
-      low_resolution = '1024x768'
-      result = xrandr_result
-      exists = result.include?("primary #{low_resolution}") # check only for primary display
-      OnlyofficeLoggerHelper.log("Real display resolution too low: #{exists}")
-      exists
-    end
   end
 end


### PR DESCRIPTION
Check if platform is not mac
Cannot use headless on mac see:
https://github.com/leonid-shevtsov/headless/issues/31#issuecomment-8933108

Drop support of low resolution display, srew them.