### PR TITLE
Sometimes on nct-at docker there is such result of xrandr

### DIFF
--- a/lib/onlyoffice_webdriver_wrapper/helpers/headless_helper/real_display_tools.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/headless_helper/real_display_tools.rb
@@ -13,7 +13,7 @@ module OnlyofficeWebdriverWrapper
     def real_display_connected?
       return true if OSHelper.mac?
       result = xrandr_result
-      exists = result.include?(' connected') # sometimes there is 'disconnected' so need a space before 'connected'
+      exists = result.include?(' connected') && !result.include?('Failed')
       OnlyofficeLoggerHelper.log("Real Display Exists: #{exists}")
       exists
     end


### PR DESCRIPTION
```
Failed to get size of gamma for output screenScreen 0: minimum 1 x 1, current 1681 x 1051, maximum 1681 x 1051screen connected 1681x1051+0+0 0mm x 0mm 1681x1051 0.00*
09:46:18/28.11.16 [real_display_tools] Real Display Exists: true
```
But real display cannot exist on this pc.
So need to check for "Failed` line and create display in such case.