### PR TITLE
Setting driver path will be deprected

### DIFF
--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -3,16 +3,15 @@ module OnlyofficeWebdriverWrapper
   module ChromeHelper
     DEFAULT_CHROME_SWITCHES = %w(--kiosk-printing --start-maximized --disable-popup-blocking test-type).freeze
 
-    # @return [Nothing] define chromedriver path
-    def define_chromedriver_path
+    # @return [String] path to chromedriver
+    def chromedriver_path
       driver_name = 'bin/chromedriver'
       driver_name = 'bin/chromedriver_mac' if OSHelper.mac?
-      Selenium::WebDriver::Chrome.driver_path = File.join(File.dirname(__FILE__), driver_name)
+      File.join(File.dirname(__FILE__), driver_name)
     end
 
     # @return [Webdriver::Chrome] Chrome webdriver
     def start_chrome_driver
-      define_chromedriver_path
       prefs = {
         download: {
           prompt_for_download: false,
@@ -27,12 +26,16 @@ module OnlyofficeWebdriverWrapper
       }
       if ip_of_remote_server.nil?
         switches = add_useragent_to_switches(DEFAULT_CHROME_SWITCHES)
+        webdriver_options = { prefs: prefs,
+                              switches: switches,
+                              http_client: client,
+                              driver_path: chromedriver_path }
         begin
-          driver = Selenium::WebDriver.for :chrome, prefs: prefs, switches: switches, http_client: client
+          driver = Selenium::WebDriver.for :chrome, webdriver_options
         rescue Selenium::WebDriver::Error::WebDriverError, Net::ReadTimeout => e # Problems with Chromedriver - hang ups
           OnlyofficeLoggerHelper.log("Starting chrome failed with error: #{e}")
           headless.reinit
-          driver = Selenium::WebDriver.for :chrome, prefs: prefs, switches: switches, http_client: client
+          driver = Selenium::WebDriver.for :chrome, webdriver_options
         end
         driver.manage.window.size = Selenium::WebDriver::Dimension.new(headless.resolution_x, headless.resolution_y) if headless.running?
         driver

--- a/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
@@ -3,7 +3,7 @@ module OnlyofficeWebdriverWrapper
   module FirefoxHelper
     # @return [Webdriver::Firefox] firefox webdriver
     def start_firefox_driver
-      Selenium::WebDriver::Firefox.driver_path = File.join(File.dirname(__FILE__), 'bin/geckodriver')
+      geckodriver = File.join(File.dirname(__FILE__), 'bin/geckodriver')
       profile = Selenium::WebDriver::Firefox::Profile.new
       profile['browser.download.folderList'] = 2
       profile['browser.helperApps.neverAsk.saveToDisk'] = 'application/doct, application/mspowerpoint, application/msword, application/octet-stream, application/oleobject, application/pdf, application/powerpoint, application/pptt, application/rtf, application/vnd.ms-excel, application/vnd.ms-powerpoint, application/vnd.oasis.opendocument.spreadsheet, application/vnd.oasis.opendocument.text, application/vnd.openxmlformats-officedocument.presentationml.presentation, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/x-compressed, application/x-excel, application/xlst, application/x-msexcel, application/x-mspowerpoint, application/x-rtf, application/x-zip-compressed, application/zip, image/jpeg, image/pjpeg, image/pjpeg, image/x-jps, message/rfc822, multipart/x-zip, text/csv, text/html, text/html, text/plain, text/richtext'
@@ -13,9 +13,9 @@ module OnlyofficeWebdriverWrapper
       if ip_of_remote_server.nil?
         driver = if Gem.loaded_specs['selenium-webdriver'].version >= Gem::Version.new(3.0)
                    # TODO: Remove this check after fix of https://github.com/SeleniumHQ/selenium/issues/2933
-                   Selenium::WebDriver.for :firefox
+                   Selenium::WebDriver.for :firefox, driver_path: geckodriver
                  else
-                   Selenium::WebDriver.for :firefox, profile: profile, http_client: client
+                   Selenium::WebDriver.for :firefox, profile: profile, http_client: client, driver_path: geckodriver
                  end
         driver.manage.window.maximize
         if headless.running?


### PR DESCRIPTION
Should send driver path as option to WebDriver
Since webdriver 3.0.3
See:
https://github.com/SeleniumHQ/selenium/pull/3158