### PR TITLE
Add check for get_files_by_prefix

### DIFF
--- a/lib/onlyoffice_webdriver_wrapper/amazon_s3_wrapper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/amazon_s3_wrapper.rb
@@ -5,7 +5,7 @@ module OnlyofficeWebdriverWrapper
   class AmazonS3Wrapper
     attr_accessor :s3, :bucket, :download_folder, :access_key_id, :secret_access_key
 
-    def initialize(bucket_name: 'nct-data-share')
+    def initialize(bucket_name: 'nct-data-share', region: 'us-west-2')
       @access_key_id = ENV['S3_KEY']
       @secret_access_key = ENV['S3_PRIVATE_KEY']
       if @access_key_id.nil? || @secret_access_key.nil?
@@ -18,16 +18,14 @@ module OnlyofficeWebdriverWrapper
       end
       Aws.config = { access_key_id: @access_key_id,
                      secret_access_key: @secret_access_key,
-                     region: 'us-west-2' }
+                     region: region }
       @s3 = Aws::S3::Resource.new
       @bucket = @s3.bucket(bucket_name)
       @download_folder = Dir.mktmpdir('amazon-s3-downloads')
     end
 
-    def get_files_by_prefix(prefix)
-      objects_array = @bucket.objects(prefix: prefix).collect(&:key)
-      objects_array.delete_at(0) # First element - is a /prefix directory
-      objects_array
+    def get_files_by_prefix(prefix = nil)
+      @bucket.objects(prefix: prefix).collect(&:key)
     end
 
     def get_object(obj_name)

--- a/spec/amazon_s3_wrapper_spec.rb
+++ b/spec/amazon_s3_wrapper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'S3 service tests' do
-  let(:s3) { OnlyofficeWebdriverWrapper::AmazonS3Wrapper.new }
+  let(:s3) { OnlyofficeWebdriverWrapper::AmazonS3Wrapper.new(bucket_name: 'nct-test-bucket', region: 'us-east-1') }
   file_name = nil
 
   before :each do
@@ -10,7 +10,17 @@ describe 'S3 service tests' do
 
   it 'get_files_by_prefix' do
     files = s3.get_files_by_prefix('docx')
-    expect(files.size).to be > 1
+    expect(files.size).to be >= 1
+  end
+
+  it 'get_files_by_prefix with empty prefix' do
+    files = s3.get_files_by_prefix(nil)
+    expect(files.size).to be >= 1
+  end
+
+  it 'get_files_by_prefix with not exist prefix' do
+    files = s3.get_files_by_prefix('notexistprefix')
+    expect(files.size).to eq(0)
   end
 
   it 'get_object' do


### PR DESCRIPTION
 because if file array is empty - method try to delete first of it(it is a path to folder, no filename)