### PR TITLE
Update to webdriver 3.4.3

### DIFF
--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -30,10 +30,11 @@ module OnlyofficeWebdriverWrapper
       }
       if ip_of_remote_server.nil?
         switches = add_useragent_to_switches(DEFAULT_CHROME_SWITCHES)
+        options = Selenium::WebDriver::Chrome::Options.new(args: switches,
+                                                           prefs: prefs)
         caps = Selenium::WebDriver::Remote::Capabilities.chrome
         caps[:logging_prefs] = { browser: 'ALL' }
-        webdriver_options = { prefs: prefs,
-                              switches: switches,
+        webdriver_options = { options: options,
                               desired_capabilities: caps,
                               driver_path: chromedriver_path }
         begin

--- a/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
@@ -10,8 +10,9 @@ module OnlyofficeWebdriverWrapper
       profile['browser.download.dir'] = @download_directory
       profile['browser.download.manager.showWhenStarting'] = false
       profile['dom.disable_window_move_resize'] = false
+      options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
       if ip_of_remote_server.nil?
-        driver = Selenium::WebDriver.for :firefox, profile: profile, driver_path: geckodriver
+        driver = Selenium::WebDriver.for :firefox, options: options, driver_path: geckodriver
         driver.manage.window.maximize
         if headless.running?
           driver.manage.window.size = Selenium::WebDriver::Dimension.new(headless.resolution_x, headless.resolution_y)

--- a/onlyoffice_webdriver_wrapper.gemspec
+++ b/onlyoffice_webdriver_wrapper.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('headless', '~> 2')
   s.add_runtime_dependency('onlyoffice_logger_helper', '~> 1')
   s.add_runtime_dependency('page-object', '~> 1')
-  s.add_runtime_dependency('selenium-webdriver', '3.4.0')
+  s.add_runtime_dependency('selenium-webdriver', '3.4.3')
   s.license = 'AGPL-3.0'
 end


### PR DESCRIPTION
```

3.4.3 (2017-06-16)
==================

Ruby:
  * Fixed a regression when passing symbol as :desired_capabilities caused NoMethodError (issue 4187).

3.4.2 (2017-06-14)
==================

Ruby:
  * Added unhandledPromptBehavior to the list of known capabilities.
  * Added timeouts to the list of known capabilities.
  * Fixed a regression when passing hash as :desired_capabilities caused NoMethodError (issue 4172, thanks Thomas Walpole).
  * Fixed a regression when extension capabilities (the ones that have ":" inside)
    were filtered out when doing protocol handshake.
  * Improved handling of capability names passed as plain camelCased strings
    vs Rubyish snake_cased symbols when doing protocol handshake.

Chrome:
  * Fixed a regression when passing :switches to driver initialization was ignored.

3.4.1 (2017-06-13)
==================

Ruby:
  * Implemented a new dual-dialect mechanism for communication with drivers
    (a.k.a. protocol handshake). There shouldn't be any noticeable differences
    but since this is a significant refactoring of internal APIs, some bugs
    could slip into the release.
  * Renamed ElementClickIntercepted to ElementClickInterceptedError.
  * Renamed ElementNotInteractable to ElementNotInteractableError.
  * Deprecated W3CCapabilities in favor of Capabilities (it was meant to be private API).
  * Added a warning when trying to save screenshot without .png extension (thanks @abotalov).

IE:
  * Added support for both old IEDriver which uses OSS dialect of JSON wire
    protocol (<= 3.4.0) and new IEDriver which uses W3C dialect (not yet released).

Safari:
  * Removed runtime dependencies used for old SafariDriver (u.g. websocket).

Chrome:
  * Added new Chrome::Options class that should be used to customize browser
    behavior (command line arguments, extensions, preferences, mobile emulation, etc.).
    The instance of options class can be passed to driver initialization using
    :options key. Old way of passing these customization directly to driver
    initialization is deprecated.

Firefox:
  * Added new Firefox::Options class that should be used to customize browser
    behavior (command line arguments, profile, preferences, Firefox binary, etc.).
    The instance of options class can be passed to driver initialization using
    :options key. Old way of passing these customization directly to driver
    initialization is deprecated.
```