### PR TITLE
Update webdriver to 3.6.0

### DIFF
--- a/onlyoffice_webdriver_wrapper.gemspec
+++ b/onlyoffice_webdriver_wrapper.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('onlyoffice_logger_helper', '~> 1')
   # since v2.1 page-object remove capability with Selenium Platform
   s.add_runtime_dependency('page-object', '~> 2.0.0')
-  s.add_runtime_dependency('selenium-webdriver', '3.5.2')
+  s.add_runtime_dependency('selenium-webdriver', '3.6.0')
   # Since `watir` 6.8 -  `cannot load such file -- watir/extensions/select_text`
   # See: https://github.com/watir/watir/issues/635
   s.add_runtime_dependency('watir', '~> 6.7.0')


### PR DESCRIPTION
Changes:
```
3.6.0 (2017-09-25)
==================

Edge:
  * Fixed a bug when execute_script failed using server + Edge (issue #4651)

Firefox:
  * Fixed a bug when web extension failed to install using profile class (issue #4093)

PhantomJS:
  * Support is deprecated in favor of headless Chrome/Firefox or HTMLUnit.
    PhantomJS is no longer actively developed, and support will eventually
    be dropped.
```