### PR TITLE
Revert "Support of `Webdriver#proxy`"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,4 +2,3 @@
 
 ## master (unreleased)
 * Remove `Webdriver#download_directory` after `Webdriver#quit`
-* Support of `Webdriver#proxy`

--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -28,13 +28,12 @@ module OnlyofficeWebdriverWrapper
         },
         credentials_enable_service: false
       }
-      caps = Selenium::WebDriver::Remote::Capabilities.chrome
-      caps[:logging_prefs] = { browser: 'ALL' }
-      caps[:proxy] = Selenium::WebDriver::Proxy.new(http: "#{@proxy.proxy_address}:#{@proxy.proxy_port}") if @proxy
       if ip_of_remote_server.nil?
         switches = add_useragent_to_switches(DEFAULT_CHROME_SWITCHES)
         options = Selenium::WebDriver::Chrome::Options.new(args: switches,
                                                            prefs: prefs)
+        caps = Selenium::WebDriver::Remote::Capabilities.chrome
+        caps[:logging_prefs] = { browser: 'ALL' }
         webdriver_options = { options: options,
                               desired_capabilities: caps,
                               driver_path: chromedriver_path }
@@ -50,6 +49,7 @@ module OnlyofficeWebdriverWrapper
         driver.manage.window.size = Selenium::WebDriver::Dimension.new(headless.resolution_x, headless.resolution_y) if headless.running?
         driver
       else
+        caps = Selenium::WebDriver::Remote::Capabilities.chrome
         caps['chromeOptions'] = {
           profile: data['zip'],
           extensions: data['extensions']

--- a/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
@@ -11,14 +11,12 @@ module OnlyofficeWebdriverWrapper
       profile['browser.download.manager.showWhenStarting'] = false
       profile['dom.disable_window_move_resize'] = false
       options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
-      caps = Selenium::WebDriver::Remote::Capabilities.firefox
-      caps[:proxy] = Selenium::WebDriver::Proxy.new(http: "#{@proxy.proxy_address}:#{@proxy.proxy_port}") if @proxy
       if ip_of_remote_server.nil?
-        driver = Selenium::WebDriver.for :firefox, options: options, driver_path: geckodriver, desired_capabilities: caps
+        driver = Selenium::WebDriver.for :firefox, options: options, driver_path: geckodriver
         driver.manage.window.size = Selenium::WebDriver::Dimension.new(headless.resolution_x, headless.resolution_y) if headless.running?
         driver
       else
-        capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(firefox_profile: profile, desired_capabilities: caps)
+        capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(firefox_profile: profile)
         Selenium::WebDriver.for :remote, desired_capabilities: capabilities, url: 'http://' + ip_of_remote_server + ':4444/wd/hub'
       end
     end

--- a/lib/onlyoffice_webdriver_wrapper/webdriver.rb
+++ b/lib/onlyoffice_webdriver_wrapper/webdriver.rb
@@ -45,21 +45,18 @@ module OnlyofficeWebdriverWrapper
     attr_accessor :download_directory
     attr_accessor :server_address
     attr_accessor :headless
-    # @return [Net::HTTP::Proxy] connection proxy
-    attr_accessor :proxy
 
     singleton_class.class_eval { attr_accessor :web_console_error }
 
-    def initialize(browser = :firefox, params = {})
+    def initialize(browser = :firefox, remote_server = nil, device: :desktop_linux)
       raise WebdriverSystemNotSupported, 'Your OS is not 64 bit. It is not supported' unless os_64_bit?
-      @device = params.fetch(:device, :desktop_linux)
+      @device = device
       @headless = HeadlessHelper.new
       @headless.start
 
       @download_directory = Dir.mktmpdir('webdriver-download')
       @browser = browser
-      @ip_of_remote_server = params.fetch(:remote_server, nil)
-      @proxy = params.fetch(:proxy, nil)
+      @ip_of_remote_server = remote_server
       case browser
       when :firefox
         @driver = start_firefox_driver


### PR DESCRIPTION
Reverts onlyoffice-testing-robot/onlyoffice_webdriver_wrapper#84

This broke starting web driver because of `ip_of_remove_server`