### PR TITLE
Update `selenium-webdriver` to 3.12.0

### DIFF
--- a/onlyoffice_webdriver_wrapper.gemspec
+++ b/onlyoffice_webdriver_wrapper.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('onlyoffice_s3_wrapper', '~> 0.1')
   # since v2.1 page-object remove capability with Selenium Platform
   s.add_runtime_dependency('page-object', '~> 2.0.0')
-  s.add_runtime_dependency('selenium-webdriver', '3.10.0')
+  s.add_runtime_dependency('selenium-webdriver', '3.12.0')
   # Since `watir` 6.8 -  `cannot load such file -- watir/extensions/select_text`
   # See: https://github.com/watir/watir/issues/635
   s.add_runtime_dependency('watir', '~> 6.7.0')


### PR DESCRIPTION
Changes are:
```
3.12.0 (2018-05-08)
===================

Ruby:
  * Added User-Agent header to requests from Selenium to give remote
    ends more visibility into distribution of clients (thanks @sah)
  * Added Selenium::WebDriver::VERSION constant (thanks @sah)
  * Added changelog link to RubyGems page
  * Fixed a bug when requests were sent with empty Content-Type,
    which should instead be application/json (issue #5615 and #5659)
  * Fixed a bug when failed connection attempt was retried without
    grace period for remote to resolve its problem (thanks @amckinley42)
  * Fixed a bug with accidentally removed HasNetworkConnection driver extension

Chrome:
  * Fixed a bug when deprecation message for using Chrome extensions
    was incorrectly shown (thanks @treby)

Safari:
  * Added support getting permissions via Driver#permissions
  * Added support setting permissions via Driver#permissions=
  * Added support enabling web inspector via Driver#attach_debugger

3.11.0 (2018-03-11)
===================

Ruby:
  * No changes in Ruby bindings for this release
```