### PR TITLE
Add `--no-sandbox` flag to running chrome

### DIFF
--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -5,6 +5,7 @@ module OnlyofficeWebdriverWrapper
                                  --start-maximized
                                  --disable-popup-blocking
                                  --disable-infobars
+                                 --no-sandbox
                                  test-type].freeze
 
     # @return [String] path to chromedriver


### PR DESCRIPTION
It will allow run chrome as root user, accroding to:
https://blog.phusion.nl/2018/05/24/using-chrome-headless-selenium-and-capybara-inside-gitlab-runner-and-docker/