### PR TITLE
Update geckodriver from 0.18 to 0.20.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,5 +4,8 @@
 * Remove `Webdriver#download_directory` after `Webdriver#quit`
 * Support of `Webdriver#proxy`
 
+### New Features
+* Update geckodriver from 0.18.0 to 0.20.1 
+
 ### Fixes
 * Fix `Webdriver#alert_exists?` for `firefox`


### PR DESCRIPTION
Changes are here:
https://github.com/mozilla/geckodriver/releases