### PR TITLE
Add `Webdriver#download` for downloading files by link

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,8 @@
 * Add method `Webdriver#browser_metadata`
 
 ### New Features
-* Update geckodriver from 0.18.0 to 0.20.1 
+* Update geckodriver from 0.18.0 to 0.20.1
+* Add `Webdriver#download` for downloading files by link
 
 ### Fixes
 * Fix `Webdriver#alert_exists?` for `firefox`

--- a/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_helper.rb
@@ -1,8 +1,22 @@
+require 'open-uri'
+require 'tempfile'
+
 module OnlyofficeWebdriverWrapper
   # Some additional methods for webdriver
   module WebdriverHelper
     def system_screenshot(file_name)
       `import -window root #{file_name}`
+    end
+
+    # Download temp file and return it location
+    # @param file [String] url
+    # @return [String] path to file
+    def download(file_url)
+      data = Kernel.open(file_url, &:read)
+      file = Tempfile.new('onlyoffice-downloaded-file')
+      file.write(data)
+      file.close
+      file.path
     end
   end
 end

--- a/spec/webdriver_firefox_spec.rb
+++ b/spec/webdriver_firefox_spec.rb
@@ -24,6 +24,11 @@ describe 'Webdriver Firefox' do
     expect(webdriver.browser_logs).not_to be_empty
   end
 
+  it 'Check that firefox can download files by direct links' do
+    result = webdriver.download('https://s3.us-west-2.amazonaws.com/nct-data-share/docx/0+(1).docx')
+    expect(File.exist?(result)).to be_truthy
+  end
+
   after do
     webdriver.quit
   end


### PR DESCRIPTION
Workaround of
https://github.com/mozilla/geckodriver/issues/1301