### PR TITLE
Remove deprecated `NoAlertOpenError`

### DIFF
--- a/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_alert_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_alert_helper.rb
@@ -12,7 +12,7 @@ module OnlyofficeWebdriverWrapper
     def alert_exists?
       @driver.switch_to.alert.text
       true
-    rescue Selenium::WebDriver::Error::NoAlertOpenError, Selenium::WebDriver::Error::NoSuchAlertError, Errno::ECONNREFUSED
+    rescue Selenium::WebDriver::Error::NoSuchAlertError, Errno::ECONNREFUSED
       false
     end
 


### PR DESCRIPTION
Since:
https://github.com/SeleniumHQ/selenium/commit/6f6af6e8e5d4dbebac45b9d185ee4326d0cb8072