### PR TITLE
Use actual travis image instead of trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
-dist: trusty
-language: ruby
+language: rugby
 before_install:
 - google-chrome --version
 - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
By default as now it's `xenial`
Trusty will cause on Chrome install via `dpkg`
```
dpkg-deb: error: archive has premature member 'control.tar.xz' before 'control.tar.gz'
```
See:
https://travis-ci.org/onlyoffice-testing-robot/onlyoffice_webdriver_wrapper/jobs/583640220