### PR TITLE
Fix downloading multiple files in Chrome

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 * Fix `WebDriver#remove_class_by_jquery`
 * Fix deprecation of `driver_path`
 * Fix quitting from already quit browser session
+* Fix downloading multiple files in Chrome
 
 ### Refactor
 

--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -28,8 +28,8 @@ module OnlyofficeWebdriverWrapper
           default_directory: download_directory
         },
         profile: {
-          default_content_settings: {
-            'multiple-automatic-downloads' => 1
+          default_content_setting_values: {
+            'automatic_downloads': 1
           }
         },
         credentials_enable_service: false


### PR DESCRIPTION
Seems flag was changed in some Chrome updates.
I'm not sure, but seems until Chrome 77 old
flag was working fine. But after update is not.
See:
https://stackoverflow.com/a/33152235/820501