### PR TITLE
Redone chrome install syntax according to docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 addons:
+  chrome: stable
   apt:
-    sources:
-      - google-chrome
     packages:
-      - google-chrome-stable
       - firefox
 
 rvm:


### PR DESCRIPTION
See:
https://travis-ci.community/t/the-following-packages-cannot-be-authenticated-google-chrome-stable/6866/2
https://docs.travis-ci.com/user/chrome#selecting-a-chrome-version
Old variant cause `unauthenticated` errors:
https://travis-ci.org/onlyoffice-testing-robot/onlyoffice_webdriver_wrapper/jobs/641257617?utm_medium=notification&utm_source=github_status