### PR TITLE
Fix `Encoding::UndefinedConversionError` for `Webdriver#download`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix `Encoding::UndefinedConversionError` for `Webdriver#download`
+
 ## 0.1.2 (2020-02-18)
 
 ### New Features

--- a/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/webdriver/webdriver_helper.rb
@@ -16,7 +16,7 @@ module OnlyofficeWebdriverWrapper
     def download(file_url)
       data = Kernel.open(file_url, &:read)
       file = Tempfile.new('onlyoffice-downloaded-file')
-      file.write(data)
+      file.write(data.force_encoding('UTF-8'))
       file.close
       file.path
     end


### PR DESCRIPTION
This error started happened for DocumentServer with test example
Don't know actual reason
File downloading by link manually is good, but this command is failing
with something like this:
```
     Encoding::UndefinedConversionError:
       "\xE2"
```