### PR TITLE
Remove support of `ip_of_remote_server`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@
 * Remove unused `Webdriver#set_text_to_iframe`
 * Remove unused `Webdriver#get_style_attributes_of_several_elements`
 * Remove `xrandr` exception handling
+* Remove support of `ip_of_remote_server`
 
 ## 0.1.2 (2020-02-18)
 

--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -38,23 +38,15 @@ module OnlyofficeWebdriverWrapper
       caps[:logging_prefs] = { browser: 'ALL' }
       caps[:proxy] = Selenium::WebDriver::Proxy.new(ssl: "#{@proxy.proxy_address}:#{@proxy.proxy_port}") if @proxy
       caps['chromeOptions'] = { w3c: false }
-      if ip_of_remote_server.nil?
-        switches = add_useragent_to_switches(DEFAULT_CHROME_SWITCHES)
-        options = Selenium::WebDriver::Chrome::Options.new(args: switches,
-                                                           prefs: prefs)
-        webdriver_options = { options: options,
-                              desired_capabilities: caps,
-                              service: chrome_service }
-        driver = Selenium::WebDriver.for :chrome, webdriver_options
-        maximize_chrome(driver)
-        driver
-      else
-        caps['chromeOptions'] = {
-          profile: data['zip'],
-          extensions: data['extensions']
-        }
-        Selenium::WebDriver.for(:remote, url: 'http://' + remote_server + ':4444/wd/hub', desired_capabilities: caps)
-      end
+      switches = add_useragent_to_switches(DEFAULT_CHROME_SWITCHES)
+      options = Selenium::WebDriver::Chrome::Options.new(args: switches,
+                                                         prefs: prefs)
+      webdriver_options = { options: options,
+                            desired_capabilities: caps,
+                            service: chrome_service }
+      driver = Selenium::WebDriver.for :chrome, webdriver_options
+      maximize_chrome(driver)
+      driver
     end
 
     private

--- a/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/firefox_helper.rb
@@ -19,14 +19,9 @@ module OnlyofficeWebdriverWrapper
       options = Selenium::WebDriver::Firefox::Options.new(profile: profile)
       caps = Selenium::WebDriver::Remote::Capabilities.firefox
       caps[:proxy] = Selenium::WebDriver::Proxy.new(ssl: "#{@proxy.proxy_address}:#{@proxy.proxy_port}") if @proxy
-      if ip_of_remote_server.nil?
-        driver = Selenium::WebDriver.for :firefox, options: options, service: firefox_service, desired_capabilities: caps
-        driver.manage.window.size = Selenium::WebDriver::Dimension.new(headless.resolution_x, headless.resolution_y) if headless.running?
-        driver
-      else
-        capabilities = Selenium::WebDriver::Remote::Capabilities.firefox(firefox_profile: profile, desired_capabilities: caps)
-        Selenium::WebDriver.for :remote, desired_capabilities: capabilities, url: 'http://' + ip_of_remote_server + ':4444/wd/hub'
-      end
+      driver = Selenium::WebDriver.for :firefox, options: options, service: firefox_service, desired_capabilities: caps
+      driver.manage.window.size = Selenium::WebDriver::Dimension.new(headless.resolution_x, headless.resolution_y) if headless.running?
+      driver
     end
 
     private

--- a/lib/onlyoffice_webdriver_wrapper/webdriver.rb
+++ b/lib/onlyoffice_webdriver_wrapper/webdriver.rb
@@ -46,7 +46,6 @@ module OnlyofficeWebdriverWrapper
     attr_reader :browser_running
     # @return [Symbol] device of which we try to simulate, default - :desktop_linux
     attr_accessor :device
-    attr_accessor :ip_of_remote_server
     attr_accessor :download_directory
     attr_accessor :server_address
     attr_accessor :headless
@@ -54,7 +53,7 @@ module OnlyofficeWebdriverWrapper
     attr_accessor :proxy
 
     def initialize(browser = :firefox,
-                   remote_server = nil,
+                   _remote_server = nil,
                    device: :desktop_linux,
                    proxy: nil)
       raise WebdriverSystemNotSupported, 'Your OS is not 64 bit. It is not supported' unless os_64_bit?
@@ -65,7 +64,6 @@ module OnlyofficeWebdriverWrapper
 
       @download_directory = Dir.mktmpdir('webdriver-download')
       @browser = browser
-      @ip_of_remote_server = remote_server
       @proxy = proxy
       case browser
       when :firefox


### PR DESCRIPTION
This feature is last used a very long time ago
In current state it'll be easier to implement remote selenium
server support from ground up, rather than trying to make
this feature working again in current code base