### PR TITLE
Remove `w3c: false` for Chrome start options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   to correct update via Dependabot
 * Drop support of rubies older, than 2.5, since
   they are EOLed
+* Remove `w3c: false` fro Chrome start options
 
 ## 0.4.0 (2020-07-30)
 

--- a/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
+++ b/lib/onlyoffice_webdriver_wrapper/helpers/chrome_helper.rb
@@ -37,7 +37,6 @@ module OnlyofficeWebdriverWrapper
       caps = Selenium::WebDriver::Remote::Capabilities.chrome
       caps[:logging_prefs] = { browser: 'ALL' }
       caps[:proxy] = Selenium::WebDriver::Proxy.new(ssl: "#{@proxy.proxy_address}:#{@proxy.proxy_port}") if @proxy
-      caps['chromeOptions'] = { w3c: false }
       switches = add_useragent_to_switches(DEFAULT_CHROME_SWITCHES)
       options = Selenium::WebDriver::Chrome::Options.new(args: switches,
                                                          prefs: prefs)


### PR DESCRIPTION
In current version of Chrome this seems to do
nothing